### PR TITLE
Adapt to newer version of tomcat 8.5: The StandardRoot needs a sort as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Then, you need to add a `src/main/webapp/META-INF/context.xml` (supposing you us
 <?xml version="1.0" encoding="UTF-8" ?>
 <Context>
 	<Loader loaderClass="fr.openwide.tomcat.catalina.loader.WebappOrderedClassLoader" />
+	<Resources className="fr.openwide.tomcat.catalina.loader.OrderedStandardRoot"/>
 </Context>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 		<jdk.version>1.7</jdk.version>
 		
-		<tomcat.version>8.5.5</tomcat.version>
+		<tomcat.version>8.5.28</tomcat.version>
 
 		<maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
 	</properties>

--- a/src/main/java/fr/openwide/tomcat/catalina/loader/OrderedStandardRoot.java
+++ b/src/main/java/fr/openwide/tomcat/catalina/loader/OrderedStandardRoot.java
@@ -1,0 +1,32 @@
+package fr.openwide.tomcat.catalina.loader;
+
+import java.util.Arrays;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.WebResource;
+import org.apache.catalina.webresources.StandardRoot;
+
+/**
+ * This StandardRoot implementation is designed to return the jar of WEB-INF lib in alphabetical order as it was the case with Tomcat
+ * 7.x.
+ * 
+ * See the discussion in https://bz.apache.org/bugzilla/show_bug.cgi?id=57129 for more information.
+ */
+public class OrderedStandardRoot extends StandardRoot {
+	public OrderedStandardRoot() {
+		super();
+	}
+
+	public OrderedStandardRoot(Context context) {
+		super(context);
+	}
+	
+	@Override
+	protected WebResource[] listResources(String path, boolean validate) {
+		WebResource[] result = super.listResources(path, validate);
+		if (OrderedWebResourceRoot.WEB_INF_LIB_PATH.equals(path)) {
+			Arrays.sort(result, OrderedWebResourceRoot.WEB_RESOURCE_COMPARATOR);
+		}
+		return result;
+	}
+}

--- a/src/main/java/fr/openwide/tomcat/catalina/loader/OrderedWebResourceRoot.java
+++ b/src/main/java/fr/openwide/tomcat/catalina/loader/OrderedWebResourceRoot.java
@@ -18,9 +18,9 @@ import org.apache.catalina.WebResourceSet;
 
 public class OrderedWebResourceRoot implements WebResourceRoot {
 
-	private static final String WEB_INF_LIB_PATH = "/WEB-INF/lib";
+	static final String WEB_INF_LIB_PATH = "/WEB-INF/lib";
 
-	private static final Comparator<WebResource> WEB_RESOURCE_COMPARATOR = new Comparator<WebResource>() {
+	static final Comparator<WebResource> WEB_RESOURCE_COMPARATOR = new Comparator<WebResource>() {
 		@Override
 		public int compare(WebResource o1, WebResource o2) {
 			return o1.getName().compareTo(o2.getName());


### PR DESCRIPTION
The current version was not working for 8.5.28 tomcat. 
Tomcat is now relying on the order from DirResourceSet.list. The patch add a StandardRoot that override the standard one for sorting content of WEB-INF/lib